### PR TITLE
feat: ミッションの達成を保存できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@
    supabase db reset
    ```
 
+## How to Use
+
+1. Create new user via [local supabase studio](http://localhost:54323/).
+  * Open "Authentication" menu
+  * Click "Add user" button & select "Create new user"
+  * Input mail address & password
+
+2. Insert a record into the private_users table using the ID of the newly created authenticated user.
+  * Open "Table Editor" menu
+  * Select private_users table
+  * Click "Insert" button & select  "Insert row"
+  * Input "id" as the ID of the newly created authenticated user id.
+
+
 ## Guidelines
 
 generate table type definition when add or update tables.

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -20,5 +20,5 @@ export async function GET(request: Request) {
   }
 
   // URL to redirect to after sign up process completes
-  return NextResponse.redirect(`${origin}/protected`);
+  return NextResponse.redirect(`${origin}/`);
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -37,14 +37,14 @@ export default function RootLayout({
         >
           <main className="min-h-screen flex flex-col items-center">
             <div className="flex-1 w-full flex flex-col gap-20 items-center">
-              {/* <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
-                <div className="w-full max-w-5xl flex justify-between items-center p-3 px-5 text-sm">
+              <nav className="w-full flex justify-center border-b border-b-foreground/10 h-16">
+                <div className="w-full max-w-2xl flex justify-between items-center p-3 px-5 text-sm">
                   <div className="flex gap-5 items-center font-semibold">
-                    <Link href={"/"}>Next.js Supabase Starter</Link>
+                    <Link href={"/"}>チームみらい</Link>
                   </div>
-                  {!hasEnvVars ? <EnvVarWarning /> : <HeaderAuth />}
+                  <HeaderAuth />
                 </div>
-              </nav> */}
+              </nav>
               <div className="flex flex-col gap-20 max-w-5xl">{children}</div>
 
               {/* <footer className="w-full flex items-center justify-center border-t mx-auto text-center text-xs gap-8 py-16">

--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -1,0 +1,36 @@
+import { achieveMissionAction } from "@/app/actions";
+import { SubmitButton } from "@/components/submit-button";
+import { createClient } from "@/utils/supabase/server";
+type Params = {
+  id: string;
+};
+
+type Props = {
+  params: Params;
+};
+
+export default async function MissionPage({ params }: Props) {
+  const { id } = params;
+  const supabase = await createClient();
+  const { data: mission, error } = await supabase
+    .from("missions")
+    .select()
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    throw new Error(`Supabase error: ${error.message}`);
+  }
+
+  if (!mission) {
+    throw new Error("Mission not found");
+  }
+
+  return (
+    <div className="flex flex-col">
+      <h1>おめでとう！</h1>
+      <p>ミッション「{mission.title}」が完了しました！</p>
+      TODO: シェア機能
+    </div>
+  );
+}

--- a/app/missions/[id]/page.tsx
+++ b/app/missions/[id]/page.tsx
@@ -1,0 +1,86 @@
+import { achieveMissionAction } from "@/app/actions";
+import { SubmitButton } from "@/components/submit-button";
+import { createClient } from "@/utils/supabase/server";
+import type { User } from "@supabase/supabase-js";
+
+type Props = {
+  params: { id: string };
+};
+
+type buttonLabelProps = {
+  authUser: User | null;
+  achievement: {
+    created_at: string;
+    id: string;
+    mission_id: string | null;
+    user_id: string | null;
+  } | null;
+};
+function buttonLabel({ authUser, achievement }: buttonLabelProps) {
+  if (authUser === null) {
+    return "ログインしてください";
+  }
+
+  if (achievement !== null) {
+    return "このミッションは完了済みです";
+  }
+
+  return "完了する";
+}
+
+export default async function MissionPage({ params }: Props) {
+  const { id } = await params;
+  const supabase = await createClient();
+
+  // 認証状態に応じてボタンを変化させるため、認証ユーザーを取得
+  const {
+    data: { user: authUser },
+  } = await supabase.auth.getUser();
+
+  // ミッション情報を取得
+  const { data: mission } = await supabase
+    .from("missions")
+    .select()
+    .eq("id", id)
+    .single();
+
+  if (!mission) {
+    throw new Error("Mission not found");
+  }
+
+  // 達成済みのものは完了ボタンをdisabledにするため、達成状況も取得
+  const { data: user } = await supabase
+    .from("private_users")
+    .select("id")
+    .single(); // 認証していない場合にはnullになる可能性がある
+
+  // 達成状況の取得
+  let achievement = null;
+
+  if (user?.id) {
+    const { data: achievementData } = await supabase
+      .from("achievements")
+      .select("*")
+      .eq("user_id", user.id)
+      .eq("mission_id", mission.id)
+      .single();
+
+    achievement = achievementData;
+  }
+
+  return (
+    <div className="flex flex-col">
+      <h1>{mission.title}</h1>
+      <p>{mission.content}</p>
+      <form className="flex-1 flex flex-col min-w-64">
+        <SubmitButton
+          pendingText="登録中..."
+          formAction={achieveMissionAction}
+          disabled={authUser === null || achievement !== null}
+        >
+          {buttonLabel({ authUser, achievement })}
+        </SubmitButton>
+      </form>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { dateTimeFormatter } from "@/utils/formatter";
 import { createClient } from "@/utils/supabase/server";
+import Link from "next/link";
 
 export default async function Home() {
   const supabase = await createClient();
@@ -216,7 +217,7 @@ function Mission({ missions }: MissionProps) {
               <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
               <AvatarFallback>アイコン</AvatarFallback>
             </Avatar>
-            <p>{mission.content}</p>
+            <Link href={`/missions/${mission.id}`}>{mission.content}</Link>
           </Card>
         ))}
       </div>

--- a/components/header-auth.tsx
+++ b/components/header-auth.tsx
@@ -1,8 +1,6 @@
 import { signOutAction } from "@/app/actions";
-import { hasEnvVars } from "@/utils/supabase/check-env-vars";
 import { createClient } from "@/utils/supabase/server";
 import Link from "next/link";
-import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
 
 export default async function AuthButton() {
@@ -11,59 +9,27 @@ export default async function AuthButton() {
   const {
     data: { user },
   } = await supabase.auth.getUser();
+  const { data: profile } = await supabase
+    .from("private_users")
+    .select("name")
+    .single();
 
-  if (!hasEnvVars) {
-    return (
-      <>
-        <div className="flex gap-4 items-center">
-          <div>
-            <Badge
-              variant={"default"}
-              className="font-normal pointer-events-none"
-            >
-              Please update .env.local file with anon key and url
-            </Badge>
-          </div>
-          <div className="flex gap-2">
-            <Button
-              asChild
-              size="sm"
-              variant={"outline"}
-              disabled
-              className="opacity-75 cursor-none pointer-events-none"
-            >
-              <Link href="/sign-in">Sign in</Link>
-            </Button>
-            <Button
-              asChild
-              size="sm"
-              variant={"default"}
-              disabled
-              className="opacity-75 cursor-none pointer-events-none"
-            >
-              <Link href="/sign-up">Sign up</Link>
-            </Button>
-          </div>
-        </div>
-      </>
-    );
-  }
-  return user ? (
+  return user && profile ? (
     <div className="flex items-center gap-4">
-      Hey, {user.email}!
+      {profile.name}
       <form action={signOutAction}>
-        <Button type="submit" variant={"outline"}>
-          Sign out
+        <Button size="sm" type="submit" variant={"outline"}>
+          ログアウト
         </Button>
       </form>
     </div>
   ) : (
     <div className="flex gap-2">
       <Button asChild size="sm" variant={"outline"}>
-        <Link href="/sign-in">Sign in</Link>
+        <Link href="/sign-in">ログイン</Link>
       </Button>
       <Button asChild size="sm" variant={"default"}>
-        <Link href="/sign-up">Sign up</Link>
+        <Link href="/sign-up">サインアップ</Link>
       </Button>
     </div>
   );

--- a/supabase/migrations/20250510122416_add_first_tables.sql
+++ b/supabase/migrations/20250510122416_add_first_tables.sql
@@ -113,7 +113,8 @@ CREATE TABLE achievements (
     mission_id UUID REFERENCES missions(id),
     user_id UUID REFERENCES public_user_profiles(id),
     evidence JSONB NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE(mission_id, user_id)
 );
 
 COMMENT ON TABLE achievements IS 'ユーザーによるミッション達成の記録';
@@ -121,20 +122,6 @@ COMMENT ON COLUMN achievements.mission_id IS '達成したミッションのID';
 COMMENT ON COLUMN achievements.user_id IS 'ミッションを達成したユーザーのID';
 COMMENT ON COLUMN achievements.evidence IS '達成の証拠(JSON形式)。達成の証拠が不要な場合は{}を入れる';
 COMMENT ON COLUMN achievements.created_at IS '記録日時(UTC)';
-
-
--- 活動タイムラインに表示するためのView
-CREATE VIEW activity_timeline_view AS
-SELECT
-  a.id,
-  p.name,
-  p.address_prefecture,
-  m.title,
-  a.created_at
-FROM achievements a
-JOIN public_user_profiles p ON a.user_id = p.id
-JOIN missions m ON a.mission_id = m.id;
-
 
 -- RLS設定
 ALTER TABLE achievements ENABLE ROW LEVEL SECURITY;
@@ -153,6 +140,19 @@ CREATE POLICY insert_own_achievement
 CREATE POLICY select_all_achievements
   ON achievements FOR SELECT
   USING (true);
+
+
+-- 活動タイムラインに表示するためのView
+CREATE VIEW activity_timeline_view AS
+SELECT
+  a.id,
+  p.name,
+  p.address_prefecture,
+  m.title,
+  a.created_at
+FROM achievements a
+JOIN public_user_profiles p ON a.user_id = p.id
+JOIN missions m ON a.mission_id = m.id;
 
 
 -- イベント

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -45,10 +45,6 @@ export const updateSession = async (request: NextRequest) => {
       return NextResponse.redirect(new URL("/sign-in", request.url));
     }
 
-    if (request.nextUrl.pathname === "/" && !user.error) {
-      return NextResponse.redirect(new URL("/protected", request.url));
-    }
-
     return response;
   } catch (e) {
     // If you are here, a Supabase client could not be created!

--- a/utils/types/supabase.ts
+++ b/utils/types/supabase.ts
@@ -38,20 +38,23 @@ export type Database = {
         Row: {
           created_at: string;
           evidence: Json;
-          mission_id: string;
-          user_id: string;
+          id: string;
+          mission_id: string | null;
+          user_id: string | null;
         };
         Insert: {
           created_at?: string;
           evidence: Json;
-          mission_id: string;
-          user_id: string;
+          id: string;
+          mission_id?: string | null;
+          user_id?: string | null;
         };
         Update: {
           created_at?: string;
           evidence?: Json;
-          mission_id?: string;
-          user_id?: string;
+          id?: string;
+          mission_id?: string | null;
+          user_id?: string | null;
         };
         Relationships: [
           {
@@ -286,6 +289,7 @@ export type Database = {
         Row: {
           address_prefecture: string | null;
           created_at: string | null;
+          id: string | null;
           name: string | null;
           title: string | null;
         };


### PR DESCRIPTION
related #7

# やったこと

## ログイン用にヘッダを出す

ミッションの登録にはユーザーの認証状態が依存するので、一旦ログインがわかりやすくできるよう、ヘッダと、ログインボタンを表示するようにした。
また、ローカル開発時に、どのように認証ユーザーや、ユーザー関連レコードを追加すればよいかをREADMEに追記した。


## ミッション詳細画面

トップ画面のミッション一覧から遷移できるミッション詳細画面を作り、その中で完了ボタンを押せるようにした。

なお、ログイン状態に応じて、ミッション詳細画面での完了ボタンの状態を切り替えるようにした。

1. 未ログイン状態(押せない)
<img width="431" alt="Screenshot 2025-05-19 at 23 48 28" src="https://github.com/user-attachments/assets/873b6997-28a1-4e5f-bb0d-d69918e710d9" />

2. ログイン済み(押せる)
<img width="432" alt="Screenshot 2025-05-19 at 23 48 42" src="https://github.com/user-attachments/assets/bf2e8b3f-768c-4963-b7b8-564d28cbdfa9" />

3. すでに完了済みの場合(押せない)
<img width="435" alt="Screenshot 2025-05-19 at 23 48 46" src="https://github.com/user-attachments/assets/77a42d82-f1db-472e-86ba-a16dc9ef5541" />

## ミッション完了画面

ミッションを完了したあとに遷移し、完了をシェアするための画面を用意した。
シェア機能は未実装です。

<img width="430" alt="Screenshot 2025-05-19 at 23 48 51" src="https://github.com/user-attachments/assets/48b60c0b-2d80-48ac-bd9f-c964a6fac6e3" />

