### PR TITLE
リクエストのbodyサイズの制限を10MBに変更(デフォルト1MB)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   /* config options here */
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "10mb",
+    },
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
fix #84

 - 大きめの画像アップロードに対応するためにBodyサイズを10MB受付可能にする