### PR TITLE
トップページのアクション数、登録人数の取得

### DIFF
--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -1,14 +1,10 @@
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
-import { createClient } from "@/utils/supabase/server";
+import { createClient, createServiceClient } from "@/utils/supabase/server";
 
 export default async function Progress() {
   const supabase = await createClient();
+  const supabaseAdmin = await createServiceClient();
 
+  /*
   const { data: dailyDashboardRegistrationSummary } = await supabase
     .from("daily_dashboard_registration_summary")
     .select()
@@ -23,19 +19,35 @@ export default async function Progress() {
 
   const registrationNum = dailyDashboardRegistrationSummary?.[0]?.count ?? 0;
   const eventNum = weeklyEventCountSummary?.[0]?.count ?? 0;
+  */
+
+  // count private_users
+  const { count } = await supabaseAdmin
+    .from("private_users")
+    .select("*", { count: "exact", head: true });
+
+  const registrationNum = count ?? "エラー";
 
   return (
     <div className="flex flex-col px-5 py-6 gap-2">
       <div className="flex flex-row justify-between items-center">
         <h2 className="text-lg font-bold">今日までの活動</h2>
-        <div className="text-xs text-gray-500">2025/xx/xx xx:xx更新</div>
+        {/*<div className="text-xs text-gray-500">2025/xx/xx xx:xx更新</div>*/}
       </div>
 
+      <div className="flex flex-row gap-2">
+        <p>アクションボード登録人数</p>
+        <p>
+          {registrationNum}
+          <span>人</span>
+        </p>
+      </div>
+      {/*
       <Accordion type="single" collapsible>
         <AccordionItem value="registration">
           <AccordionTrigger>
             <div className="flex flex-row gap-2">
-              <p>ダッシュボード登録人数</p>
+              <p>アクションボード登録人数</p>
               <p>
                 {registrationNum}
                 <span>人</span>
@@ -44,7 +56,8 @@ export default async function Progress() {
           </AccordionTrigger>
           <AccordionContent>本当はここに日本地図が入る</AccordionContent>
         </AccordionItem>
-        {/*
+        */}
+      {/*
         <AccordionItem value="event">
           <AccordionTrigger>
             <div className="flex flex-row gap-2">
@@ -58,7 +71,6 @@ export default async function Progress() {
           <AccordionContent>本当はここに日本地図が入る</AccordionContent>
         </AccordionItem>
         */}
-      </Accordion>
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "autoprefixer": "10.4.20",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "date-fns": "^4.1.0",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.468.0",
         "next": "latest",
         "next-themes": "^0.4.3",
@@ -5629,6 +5631,25 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "devOptional": true
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "autoprefixer": "10.4.20",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "date-fns": "^4.1.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.468.0",
     "next": "latest",
     "next-themes": "^0.4.3",


### PR DESCRIPTION
バッチ集計は初期スコープ外という話だったかと思うのでオンライン集計でできる範囲でトップページの集計系の表示をしました。