### PR TITLE
chromeの警告修正 。パスワードマネージャ向けの autocomplete 追加

### DIFF
--- a/app/(auth-pages)/forgot-password/page.tsx
+++ b/app/(auth-pages)/forgot-password/page.tsx
@@ -18,7 +18,12 @@ export default async function ForgotPassword(props: {
         <h1 className="text-2xl font-medium">パスワードを忘れた方</h1>
         <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
           <Label htmlFor="email">Email</Label>
-          <Input name="email" placeholder="you@example.com" required />
+          <Input
+            name="email"
+            placeholder="you@example.com"
+            required
+            autoComplete="username"
+          />
           <SubmitButton formAction={forgotPasswordAction}>
             パスワードリセットメールを送信
           </SubmitButton>

--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -22,7 +22,12 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
       </p>
       <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
         <Label htmlFor="email">Email</Label>
-        <Input name="email" placeholder="you@example.com" required />
+        <Input
+          name="email"
+          placeholder="you@example.com"
+          required
+          autoComplete="username"
+        />
         <div className="flex justify-between items-center">
           <Label htmlFor="password">Password</Label>
           <Link
@@ -37,6 +42,7 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
           name="password"
           placeholder="Your password"
           required
+          autoComplete="current-password"
         />
         <SubmitButton pendingText="Signing In..." formAction={signInAction}>
           ログイン

--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -37,6 +37,7 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
           placeholder="you@example.com"
           required
           disabled={isSuccess}
+          autoComplete="username"
         />
         <Label htmlFor="password">Password</Label>
         <Input
@@ -46,6 +47,7 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
           minLength={6}
           required
           disabled={isSuccess}
+          autoComplete="new-password"
         />
 
         <div className="flex flex-col gap-3 mb-4">

--- a/app/(protected)/reset-password/page.tsx
+++ b/app/(protected)/reset-password/page.tsx
@@ -20,6 +20,7 @@ export default async function ResetPassword(props: {
         name="password"
         placeholder="New password"
         required
+        autoComplete="new-password"
       />
       <Label htmlFor="confirmPassword">Confirm password</Label>
       <Input
@@ -27,6 +28,7 @@ export default async function ResetPassword(props: {
         name="confirmPassword"
         placeholder="Confirm password"
         required
+        autoComplete="new-password"
       />
       <SubmitButton formAction={resetPasswordAction}>
         Reset password


### PR DESCRIPTION
パスワードマネージャー向けに autocomplete を設定しましょうというwarningsが出ていたので対応

参考
https://www.chromium.org/developers/design-documents/create-amazing-password-forms/