### PR TITLE
ダッシュボード[ミッション]のUI改善

### DIFF
--- a/components/mission/mission.tsx
+++ b/components/mission/mission.tsx
@@ -77,7 +77,7 @@ export default function Mission({
         <Link href={`/missions/${mission.id}`} className="w-full">
           <button
             type="button"
-            className="w-full bg-[#101828] text-white rounded-lg py-2 text-sm hover:bg-[#1a2533] transition"
+            className="w-full bg-[#101828] text-white rounded-lg py-2 text-sm hover:bg-[#1a2533] hover:opacity-50 transition"
           >
             詳細を見る
           </button>


### PR DESCRIPTION
- [issue#96](https://github.com/team-mirai/action-board/issues/96)

- 変更内容
ミッションの[詳細を見る]にカーソルを合わせたときに表示が薄くなって直感的に押下しやすく変更しました。

- 修正後
<img width="1470" alt="スクリーンショット 2025-05-24 0 18 25" src="https://github.com/user-attachments/assets/4ac49b28-900e-4920-8029-f061fb84576d" />
