### PR TITLE
README.md を更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 * 「Table Editor」メニューを開く
 * `private_users` テーブルを選択
 * 「Insert」ボタンをクリックし、「Insert row」を選択
-* 「id」欄に先ほど作成したsupabase認証ユーザーの ID を入力
+* 「auth_id」欄に先ほど作成したsupabase認証ユーザーの ID を入力
 * その他の欄はよしなに入力する
 
 


### PR DESCRIPTION
- private_users の id -> auth_id に変更

README.mdを参照しながらNext.js / supabaseの設定を行っていたのですが、その後のコードなどを見ても private_usersのidではなく、auth_id な気がしたので修正（違っていたらすいません）

issueが別途必要であればあげて紐付けます、ご確認お願いします