### PR TITLE
fix: サービスロールを用いたクライアントでなく通常のsupabaseクライアントでデータ取得できる箇所はそれで取る

### DIFF
--- a/components/activities.tsx
+++ b/components/activities.tsx
@@ -1,13 +1,12 @@
 import { ActivityTimeline } from "@/components/activity-timeline";
 import { Card } from "@/components/ui/card";
 import { dateTimeFormatter } from "@/lib/formatter";
-import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/server";
 import { toZonedTime } from "date-fns-tz";
 import Link from "next/link";
 
 export default async function Activities() {
   const supabase = await createClient();
-  const supabaseAdmin = await createServiceClient();
 
   const { data: dailyActionSummary } = await supabase
     .from("daily_action_summary")
@@ -16,7 +15,7 @@ export default async function Activities() {
     .limit(2);
 
   // count achievements
-  const { count: achievementCount } = await supabaseAdmin
+  const { count: achievementCount } = await supabase
     .from("achievements")
     .select("*", { count: "exact", head: true });
 
@@ -25,7 +24,7 @@ export default async function Activities() {
   const date = toZonedTime(new Date(), timeZone);
   date.setHours(0, 0, 0, 0);
 
-  const { count: todayAchievementCount } = await supabaseAdmin
+  const { count: todayAchievementCount } = await supabase
     .from("achievements")
     .select("*", { count: "exact", head: true })
     .gte("created_at", date.toISOString());

--- a/components/progress.tsx
+++ b/components/progress.tsx
@@ -1,8 +1,7 @@
-import { createClient, createServiceClient } from "@/lib/supabase/server";
+import { createClient } from "@/lib/supabase/server";
 
 export default async function Progress() {
   const supabase = await createClient();
-  const supabaseAdmin = await createServiceClient();
 
   /*
   const { data: dailyDashboardRegistrationSummary } = await supabase
@@ -21,9 +20,9 @@ export default async function Progress() {
   const eventNum = weeklyEventCountSummary?.[0]?.count ?? 0;
   */
 
-  // count private_users
-  const { count } = await supabaseAdmin
-    .from("private_users")
+  // ユーザー数を数える
+  const { count } = await supabase
+    .from("public_user_profiles")
     .select("*", { count: "exact", head: true });
 
   const registrationNum = count ?? "エラー";


### PR DESCRIPTION
# 背景

できるだけサービスロールを用いたクライアントを利用しないようにしたいと考えました。
サービスロールを用いたクライアントは権限が強く、意図しない使い方が起こる可能性を懸念しました。

# やったこと

* 既存の、アクティビティ数の集計を、サービスロールでないsupabaseクライアントで集計しました。
* ユーザーの登録数を、RLS制約のため認証ユーザーのみアクセスできるprivate_usersテーブルではなく、private_usersテーブルの登録時にtriggerで同じ件数追加されるはずの、全員がselect可能な、public_user_profilesのcountで得るようにしました。