### PR TITLE
Facebook、Lineのシェアボタンを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-# Update these with your Supabase details from your project settings > API
-# https://app.supabase.com/project/_/settings/api
-NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
-NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
-SUPABASE_SERVICE_ROLE_KEY=service-role-key

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Update these with your Supabase details from your project settings > API
+# https://app.supabase.com/project/_/settings/api
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=service-role-key

--- a/app/missions/[id]/complete/ShareFacebookButton.tsx
+++ b/app/missions/[id]/complete/ShareFacebookButton.tsx
@@ -17,8 +17,8 @@ export function ShareFacebookButton({
 }: Props) {
   const shareUrl = url ?? `${window.location.origin}/missions/${missionId}`;
   const handleShare = () => {
-    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
-    window.open(facebookUrl, "_blank", "noopener,noreferrer");
+    const facebookIntentUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
+    window.open(facebookIntentUrl, "_blank", "noopener,noreferrer");
   };
 
   return (

--- a/app/missions/[id]/complete/ShareFacebookButton.tsx
+++ b/app/missions/[id]/complete/ShareFacebookButton.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  children: React.ReactNode;
+  missionId: string;
+  className?: string;
+  url?: string;
+};
+
+export function ShareFacebookButton({
+  children,
+  missionId,
+  className,
+  url,
+}: Props) {
+  const shareUrl = url ?? `${window.location.origin}/missions/${missionId}`;
+  const handleShare = () => {
+    const facebookUrl = `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`;
+    window.open(facebookUrl, "_blank", "noopener,noreferrer");
+  };
+
+  return (
+    <Button variant="outline" onClick={handleShare} className={className}>
+      {children}
+    </Button>
+  );
+}

--- a/app/missions/[id]/complete/ShareLineButton.tsx
+++ b/app/missions/[id]/complete/ShareLineButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+
+type Props = {
+  children: React.ReactNode;
+  missionId: string;
+  className?: string;
+  url?: string;
+};
+
+const isMobile =
+  typeof window !== "undefined" &&
+  /iPhone|Android.+Mobile/.test(navigator.userAgent);
+
+export function ShareLineButton({
+  children,
+  missionId,
+  className,
+  url,
+}: Props) {
+  // SNSシェア用のハンドラ関数
+  const shareUrl = url ?? `${window.location.origin}/missions/${missionId}`;
+  const handleShare = () => {
+    const lineIntentUrl = `https://social-plugins.line.me/lineit/share?url=${encodeURIComponent(shareUrl)}`;
+    window.open(lineIntentUrl, "_blank", "noopener,noreferrer");
+  };
+  return (
+    isMobile && (
+      <Button variant="outline" onClick={handleShare} className={className}>
+        {children}
+      </Button>
+    )
+  );
+}

--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -51,11 +51,7 @@ export default async function MissionPage({ params }: Props) {
         Lineでシェア
       </ShareLineButton>
       {/* navigator.share()を使っているのでモバイルのみ表示 */}
-      <ShareButton
-        className="mt-2 md:hidden"
-        message={shareMessage}
-        missionId={id}
-      >
+      <ShareButton className="mt-4" message={shareMessage} missionId={id}>
         その他のサービスにシェア
       </ShareButton>
     </div>

--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -47,11 +47,15 @@ export default async function MissionPage({ params }: Props) {
         Facebookでシェア
       </ShareFacebookButton>
       {/* 内部で判定しておりモバイルのみ表示 */}
-      <ShareLineButton className="mt-4" missionId={id}>
+      <ShareLineButton className="mt-4 md:hidden" missionId={id}>
         Lineでシェア
       </ShareLineButton>
       {/* navigator.share()を使っているのでモバイルのみ表示 */}
-      <ShareButton className="mt-4" message={shareMessage} missionId={id}>
+      <ShareButton
+        className="mt-4 md:hidden"
+        message={shareMessage}
+        missionId={id}
+      >
         その他のサービスにシェア
       </ShareButton>
     </div>

--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -1,7 +1,9 @@
 import { createClient } from "@/utils/supabase/server";
 import { ShareButton } from "./ShareButton";
 import { ShareFacebookButton } from "./ShareFacebookButton";
+import { ShareLineButton } from "./ShareLineButton";
 import { ShareTwitterButton } from "./ShareTwitterButton";
+
 type Params = {
   id: string;
 };
@@ -44,7 +46,11 @@ export default async function MissionPage({ params }: Props) {
       <ShareFacebookButton className="mt-4" missionId={id}>
         Facebookでシェア
       </ShareFacebookButton>
-      {/* navigator.share()を使っているのモバイルのみ表示 */}
+      {/* 内部で判定しておりモバイルのみ表示 */}
+      <ShareLineButton className="mt-4" missionId={id}>
+        Lineでシェア
+      </ShareLineButton>
+      {/* navigator.share()を使っているのでモバイルのみ表示 */}
       <ShareButton
         className="mt-2 md:hidden"
         message={shareMessage}

--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/utils/supabase/server";
 import { ShareButton } from "./ShareButton";
+import { ShareFacebookButton } from "./ShareFacebookButton";
 import { ShareTwitterButton } from "./ShareTwitterButton";
 type Params = {
   id: string;
@@ -40,6 +41,9 @@ export default async function MissionPage({ params }: Props) {
       >
         Xでシェア
       </ShareTwitterButton>
+      <ShareFacebookButton className="mt-4" missionId={id}>
+        Facebookでシェア
+      </ShareFacebookButton>
       {/* navigator.share()を使っているのモバイルのみ表示 */}
       <ShareButton
         className="mt-2 md:hidden"

--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -43,7 +43,8 @@ export default async function MissionPage({ params }: Props) {
       >
         Xでシェア
       </ShareTwitterButton>
-      <ShareFacebookButton className="mt-4" missionId={id}>
+      {/* PCでURLが投稿に表示されないため現時点ではモバイルのみで表示 */}
+      <ShareFacebookButton className="mt-4 md:hidden" missionId={id}>
         Facebookでシェア
       </ShareFacebookButton>
       {/* 内部で判定しておりモバイルのみ表示 */}


### PR DESCRIPTION
## 🔧 概要

ミッション完了ページに、以下のSNSシェアボタンを追加しました：

- **Facebook**：すべてのデバイスで表示
- **LINE**：モバイルデバイスでのみ表示

 🔗 関連Issue: https://github.com/team-mirai/action-board/issues/50

---


## 🛠 主な変更点

- `ShareFacebookButton.tsx` と `ShareLineButton.tsx` の追加
- `page.tsx` へのボタン配置と、モバイル表示の調整（Tailwindの `md:hidden` 使用）
- 余白クラスを統一し、見た目を揃えました

---

## ✅ 動作確認済み内容

- Facebookシェアが動作すること
- LINEボタンがモバイル環境でのみ表示されること

---

## 💬 補足

TypeScript、Next.jsは学習中のため、ご指摘・改善提案あればいただけると嬉しいです 🙇‍♂️
