### PR TITLE
PC環境でもFacebookシェアボタンを有効にする

### DIFF
--- a/app/missions/[id]/complete/page.tsx
+++ b/app/missions/[id]/complete/page.tsx
@@ -43,8 +43,7 @@ export default async function MissionPage({ params }: Props) {
       >
         Xでシェア
       </ShareTwitterButton>
-      {/* PCでURLが投稿に表示されないため現時点ではモバイルのみで表示 */}
-      <ShareFacebookButton className="mt-4 md:hidden" missionId={id}>
+      <ShareFacebookButton className="mt-4" missionId={id}>
         Facebookでシェア
       </ShareFacebookButton>
       {/* 内部で判定しておりモバイルのみ表示 */}


### PR DESCRIPTION
暫定的にFacebookシェアボタンをPC環境で隠していたのを表示するようにします

コンテキスト
[Facebook、Lineのシェアボタンを追加](https://github.com/team-mirai/action-board/pull/123)
[FacebookシェアURLがPCで正しく機能しない](https://github.com/team-mirai/action-board/issues/129)