### PR TITLE
間延び対策で表示領域を狭める

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -33,7 +33,7 @@ export default function RootLayout({
           disableTransitionOnChange
         >
           <Navbar />
-          <main className="md:container md:mx-auto flex flex-col items-center">
+          <main className="max-w-3xl mx-auto flex flex-col items-center">
             {children}
           </main>
         </ThemeProvider>

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -21,8 +21,8 @@ export default async function Navbar() {
   } = await supabase.auth.getUser();
 
   return (
-    <nav className="sticky top-0 z-50 w-full flex justify-center bg-white border-b border-b-foreground/10 h-16">
-      <div className="px-4 md:container md:mx-auto w-full flex justify-between items-center text-sm">
+    <nav className="sticky top-0 z-50 max-w-3xl mx-auto flex justify-center bg-white h-16">
+      <div className="px-2 md:px-0 w-full flex justify-between items-center text-sm border-b border-b-foreground/10 ">
         <div className="flex gap-5 items-center font-semibold min-w-[60px]">
           <Link href="/">
             <Image src="/img/logo.png" alt="logo" width={57} height={48} />


### PR DESCRIPTION
 - 解像度高めのディスプレイだと間延びした印象があったので横幅を制限してみました
 - タイムラインが顕著
 - ついでの navbar も同じ横幅に収まるようにしています

これが良い対応かいまいち自信ないので忌憚なきご意見をいただけると助かります。

対応後
![localhost_3000_](https://github.com/user-attachments/assets/7cf6f515-c4c7-4ced-ada2-2d8e6905701e)

対応前
![localhost_3000_ (2)](https://github.com/user-attachments/assets/21c0da6d-435d-48c6-9df6-c67033386dd7)
