### PR TITLE
メールテンプレートの設定

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -178,6 +178,21 @@ otp_expiry = 3600
 # [auth.email.template.invite]
 # subject = "You have been invited"
 # content_path = "./supabase/templates/invite.html"
+[auth.email.template.confirmation]
+subject = "チームみらいアクションボード メールアドレス確認"
+content_path = "./supabase/templates/confirmation.html"
+[auth.email.template.invite]
+subject = "チームみらいアクションボード 招待メール"
+content_path = "./supabase/templates/invite.html"
+[auth.email.template.recovery]
+subject = "チームみらいアクションボード パスワードリセット"
+content_path = "./supabase/templates/recovery.html"
+[auth.email.template.magic_link]
+subject = "チームみらいアクションボード ログインメール"
+content_path = "./supabase/templates/magic_link.html"
+[auth.email.template.email_change]
+subject = "チームみらいアクションボード メールアドレス変更"
+content_path = "./supabase/templates/email_change.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,53 @@
+<div style="
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px 20px;
+  font-size: 16px;
+  line-height: 1.6;
+  text-align: left;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+">
+
+<p style="text-align:center; margin-bottom: 28px;">
+  <img src="https://team-mir.ai/_astro/logo_main.9dMQvXbz_cEoDX.webp" alt="チームみらいアクションボード" style="width:100px;height:100px;margin:0 auto;">
+</p>
+
+<h2 style="margin-bottom: 28px;">チームみらいアクションボード メールアドレス確認</h2>
+
+<p style="margin-bottom: 28px;">チームみらいアクションボードにログインするには、以下のボタンをクリックしてください。</p>
+
+<div style="text-align: center; margin: 32px 0;">
+  <a href="{{ .ConfirmationURL }}" style="
+    display: inline-block;
+    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    color: white;
+    text-decoration: none;
+    padding: 16px 32px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  ">
+    メールアドレスを確認する
+  </a>
+</div>
+
+<!-- Footer -->
+<hr style="border-top:1px solid #eaeaea;margin:26px 0;width:100%;color:#eaeaea">
+
+<div style="font-size:12px;color:#666;margin-top:20px;">
+  <p>チームみらいアクションボード<br/>
+  <a href="https://action.team-mir.ai/">https://action.team-mir.ai/</a></p>
+  
+  <p>チームみらい<br/>
+  <a href="https://team-mir.ai/">https://team-mir.ai/</a></p>
+
+  <p>© 2025 Team Mirai</p>
+</div>
+
+</div>

--- a/supabase/templates/email_change.html
+++ b/supabase/templates/email_change.html
@@ -1,0 +1,60 @@
+<div style="
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px 20px;
+  font-size: 16px;
+  line-height: 1.6;
+  text-align: left;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+">
+
+<p style="text-align:center; margin-bottom: 28px;">
+  <img src="https://team-mir.ai/_astro/logo_main.9dMQvXbz_cEoDX.webp" alt="チームみらいアクションボード" style="width:100px;height:100px;margin:0 auto;">
+</p>
+
+<h2 style="margin-bottom: 28px;">チームみらいアクションボード メールアドレス変更</h2>
+
+<p style="margin-bottom: 28px;">
+    メールアドレスの変更リクエストを受け付けました。<br/>
+    新しいメールアドレス: {{ .NewEmail }}<br/>
+    <br/>
+    以下のボタンをクリックして、メールアドレスの変更を確認してください。
+</p>
+
+<div style="text-align: center; margin: 32px 0;">
+  <a href="{{ .ConfirmationURL }}" style="
+    display: inline-block;
+    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    color: white;
+    text-decoration: none;
+    padding: 16px 32px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  ">
+    メールアドレス変更を確認する
+  </a>
+</div>
+
+<p style="margin-bottom: 28px;">このリンクは一定時間後に無効になります。もしメールアドレス変更をリクエストしていない場合は、このメールを無視してください。</p>
+
+<!-- Footer -->
+<hr style="border-top:1px solid #eaeaea;margin:26px 0;width:100%;color:#eaeaea">
+
+<div style="font-size:12px;color:#666;margin-top:20px;">
+  <p>チームみらいアクションボード<br/>
+  <a href="https://action.team-mir.ai/">https://action.team-mir.ai/</a></p>
+  
+  <p>チームみらい<br/>
+  <a href="https://team-mir.ai/">https://team-mir.ai/</a></p>
+
+  <p>© 2025 Team Mirai</p>
+</div> 
+
+</div>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,58 @@
+<div style="
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px 20px;
+  font-size: 16px;
+  line-height: 1.6;
+  text-align: left;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+">
+
+<p style="text-align:center; margin-bottom: 28px;">
+  <img src="https://team-mir.ai/_astro/logo_main.9dMQvXbz_cEoDX.webp" alt="チームみらいアクションボード" style="width:100px;height:100px;margin:0 auto;">
+</p>
+
+<h2 style="margin-bottom: 28px;">チームみらいアクションボード 招待メール</h2>
+
+<p style="margin-bottom: 28px;">
+    チームみらいアクションボードの招待が届きました。<br/>
+    ログインするには、以下のボタンをクリックしてください。
+</p>
+
+<div style="text-align: center; margin: 32px 0;">
+  <a href="{{ .ConfirmationURL }}" style="
+    display: inline-block;
+    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    color: white;
+    text-decoration: none;
+    padding: 16px 32px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  ">
+    招待を受け入れる
+  </a>
+</div>
+
+<p style="margin-bottom: 28px;">このリンクは一定時間後に無効になります。お早めにご利用ください。</p>
+
+<!-- Footer -->
+<hr style="border-top:1px solid #eaeaea;margin:26px 0;width:100%;color:#eaeaea">
+
+<div style="font-size:12px;color:#666;margin-top:20px;">
+  <p>チームみらいアクションボード<br/>
+  <a href="https://action.team-mir.ai/">https://action.team-mir.ai/</a></p>
+  
+  <p>チームみらい<br/>
+  <a href="https://team-mir.ai/">https://team-mir.ai/</a></p>
+
+  <p>© 2025 Team Mirai</p>
+</div> 
+
+</div>

--- a/supabase/templates/magic_link.html
+++ b/supabase/templates/magic_link.html
@@ -1,0 +1,58 @@
+<div style="
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px 20px;
+  font-size: 16px;
+  line-height: 1.6;
+  text-align: left;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+">
+
+<p style="text-align:center; margin-bottom: 28px;">
+  <img src="https://team-mir.ai/_astro/logo_main.9dMQvXbz_cEoDX.webp" alt="チームみらいアクションボード" style="width:100px;height:100px;margin:0 auto;">
+</p>
+
+<h2 style="margin-bottom: 28px;">チームみらいアクションボード ログインメール</h2>
+
+<p style="margin-bottom: 28px;">
+    チームみらいアクションボードへのログインリンクをお送りします。<br/>
+    ログインするには、以下のボタンをクリックしてください。
+</p>
+
+<div style="text-align: center; margin: 32px 0;">
+  <a href="{{ .ConfirmationURL }}" style="
+    display: inline-block;
+    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    color: white;
+    text-decoration: none;
+    padding: 16px 32px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  ">
+    ログインする
+  </a>
+</div>
+
+<p style="margin-bottom: 28px;">このリンクは一定時間後に無効になります。もしログインをリクエストしていない場合は、このメールを無視してください。</p>
+
+<!-- Footer -->
+<hr style="border-top:1px solid #eaeaea;margin:26px 0;width:100%;color:#eaeaea">
+
+<div style="font-size:12px;color:#666;margin-top:20px;">
+  <p>チームみらいアクションボード<br/>
+  <a href="https://action.team-mir.ai/">https://action.team-mir.ai/</a></p>
+  
+  <p>チームみらい<br/>
+  <a href="https://team-mir.ai/">https://team-mir.ai/</a></p>
+
+  <p>© 2025 Team Mirai</p>
+</div> 
+
+</div>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,58 @@
+<div style="
+  width: 100%;
+  max-width: 600px;
+  margin: 0 auto;
+  padding: 24px 20px;
+  font-size: 16px;
+  line-height: 1.6;
+  text-align: left;
+  font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+  background-color: #ffffff;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+">
+
+<p style="text-align:center; margin-bottom: 28px;">
+  <img src="https://team-mir.ai/_astro/logo_main.9dMQvXbz_cEoDX.webp" alt="チームみらいアクションボード" style="width:100px;height:100px;margin:0 auto;">
+</p>
+
+<h2 style="margin-bottom: 28px;">チームみらいアクションボード パスワードリセット</h2>
+
+<p style="margin-bottom: 28px;">
+    パスワードリセットのリクエストを受け付けました。<br/>
+    新しいパスワードを設定するには、以下のボタンをクリックしてください。
+</p>
+
+<div style="text-align: center; margin: 32px 0;">
+  <a href="{{ .ConfirmationURL }}" style="
+    display: inline-block;
+    background: linear-gradient(135deg, hsl(158, 64%, 42%) 0%, hsl(173, 58%, 39%) 100%);
+    color: white;
+    text-decoration: none;
+    padding: 16px 32px;
+    border-radius: 12px;
+    font-weight: bold;
+    font-size: 16px;
+    font-family: -apple-system, BlinkMacSystemFont, 'Hiragino Kaku Gothic ProN', 'Yu Gothic', Meiryo, sans-serif;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06);
+  ">
+    パスワードをリセットする
+  </a>
+</div>
+
+<p style="margin-bottom: 28px;">このリンクは一定時間後に無効になります。もしパスワードリセットをリクエストしていない場合は、このメールを無視してください。</p>
+
+<!-- Footer -->
+<hr style="border-top:1px solid #eaeaea;margin:26px 0;width:100%;color:#eaeaea">
+
+<div style="font-size:12px;color:#666;margin-top:20px;">
+  <p>チームみらいアクションボード<br/>
+  <a href="https://action.team-mir.ai/">https://action.team-mir.ai/</a></p>
+  
+  <p>チームみらい<br/>
+  <a href="https://team-mir.ai/">https://team-mir.ai/</a></p>
+
+  <p>© 2025 Team Mirai</p>
+</div> 
+
+</div>


### PR DESCRIPTION
fix #67 

 - いったん使ってないものも含めて全部設定しておきました
 - publicな場所にロゴ画像がまだ配備されていないため、政党LPのページに直リンクさせてもらってます。

デザイン
<img width="710" alt="image" src="https://github.com/user-attachments/assets/8a815293-ea48-457f-af74-b4c899919193" />
