### PR TITLE
サインイン/サインアップのメッセージ周りのUI改善

### DIFF
--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -20,6 +20,7 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
           こちら
         </Link>
       </p>
+      <FormMessage className="mt-8" message={searchParams} />
       <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
         <Label htmlFor="email">メールアドレス</Label>
         <Input
@@ -47,7 +48,6 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
         <SubmitButton pendingText="Signing In..." formAction={signInAction}>
           ログイン
         </SubmitButton>
-        <FormMessage message={searchParams} />
       </div>
     </form>
   );

--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -65,6 +65,7 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
           こちら
         </Link>
       </p>
+      <FormMessage className="mt-8" message={searchParams} />
       <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
         <Label htmlFor="email">メールアドレス</Label>
         <Input
@@ -166,7 +167,6 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
         >
           サインアップ
         </SubmitButton>
-        <FormMessage message={searchParams} />
       </div>
     </form>
   );

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -39,7 +39,7 @@ const signInAndLoginFormSchema = z.object({
   password: z
     .string()
     .nonempty({ message: "パスワードを入力してください" })
-    .min(6, { message: "パスワードは8文字以上で入力してください" }),
+    .min(8, { message: "パスワードは8文字以上で入力してください" }),
 });
 
 export const signUpAction = async (formData: FormData) => {
@@ -119,10 +119,12 @@ export const signInAction = async (formData: FormData) => {
     password,
   });
 
-  console.log(error);
-
   if (error) {
-    return encodedRedirect("error", "/sign-in", error.message);
+    return encodedRedirect(
+      "error",
+      "/sign-in",
+      "メールアドレスまたはパスワードが間違っています",
+    );
   }
 
   return redirect("/");

--- a/components/form-message.tsx
+++ b/components/form-message.tsx
@@ -1,4 +1,5 @@
 import clsx from "clsx";
+import { CheckCircle, Info, XCircle } from "lucide-react";
 
 export type Message =
   | { success: string }
@@ -9,23 +10,44 @@ export function FormMessage({
   className,
   message,
 }: { className?: string; message: Message }) {
+  if (
+    !message ||
+    !("success" in message || "error" in message || "message" in message)
+  )
+    return null;
+
   return (
     <div
-      className={clsx("flex flex-col gap-2 w-full max-w-md text-sm", className)}
+      className={clsx(
+        "relative flex items-start gap-3 w-full max-w-md p-4 rounded-xl",
+        "border text-card-foreground shadow-soft-lg",
+        {
+          "bg-green-50 border-green-200": "success" in message,
+          "bg-red-50 border-red-200": "error" in message,
+          "bg-blue-50 border-blue-200": "message" in message,
+        },
+        className,
+      )}
     >
       {"success" in message && (
-        <div className="text-foreground border-l-2 border-foreground px-4 whitespace-pre-wrap">
-          {message.success}
+        <div className="flex-1">
+          <div className="text-sm text-green-700 whitespace-pre-wrap leading-relaxed">
+            {message.success}
+          </div>
         </div>
       )}
       {"error" in message && (
-        <div className="text-destructive border-l-2 border-destructive px-4 whitespace-pre-wrap">
-          {message.error}
+        <div className="flex-1">
+          <div className="text-sm text-red-700 whitespace-pre-wrap leading-relaxed">
+            {message.error}
+          </div>
         </div>
       )}
       {"message" in message && (
-        <div className="text-foreground border-l-2 px-4 whitespace-pre-wrap">
-          {message.message}
+        <div className="flex-1">
+          <div className="text-sm text-blue-700 whitespace-pre-wrap leading-relaxed">
+            {message.message}
+          </div>
         </div>
       )}
     </div>

--- a/components/form-message.tsx
+++ b/components/form-message.tsx
@@ -1,11 +1,18 @@
+import clsx from "clsx";
+
 export type Message =
   | { success: string }
   | { error: string }
   | { message: string };
 
-export function FormMessage({ message }: { message: Message }) {
+export function FormMessage({
+  className,
+  message,
+}: { className?: string; message: Message }) {
   return (
-    <div className="flex flex-col gap-2 w-full max-w-md text-sm">
+    <div
+      className={clsx("flex flex-col gap-2 w-full max-w-md text-sm", className)}
+    >
       {"success" in message && (
         <div className="text-foreground border-l-2 border-foreground px-4 whitespace-pre-wrap">
           {message.success}


### PR DESCRIPTION
# 変更の概要

 - パスワード誤り時のメッセージが日本語になるように修正
 - メッセージ表示位置をボタンの下からフォームの上に変更
 - メッセージのUIをレベルが背景色で分かるように修正

<img width="375" alt="image" src="https://github.com/user-attachments/assets/85114b15-261b-4808-aea5-44cb9442014d" />

<img width="512" alt="image" src="https://github.com/user-attachments/assets/906285c4-a7ab-4f29-9193-858835dde212" />

# 変更の背景

 - メッセージが目立たず次のアクションが取りづらくなるため

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました