### PR TITLE
ローカル環境でサインアップ後に自動ログインできない問題の修正

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -105,7 +105,7 @@ enabled = true
 enabled = true
 # The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
 # in emails.
-site_url = "http://127.0.0.1:3000"
+site_url = "http://localhost:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
 additional_redirect_urls = ["https://127.0.0.1:3000"]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).


### PR DESCRIPTION
# 変更の概要

- 127.0.0.1 に対してクッキーが付与され、その後 localhost にリダイレクトされるのでクッキー付与されない動作になっていた。

# 変更の背景

- ローカル環境でサインアップ後に自動ログインできない

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました