### PR TITLE
ユーザー詳細のアバターに関する修正

### DIFF
--- a/app/users/[id]/page.tsx
+++ b/app/users/[id]/page.tsx
@@ -1,5 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Card } from "@/components/ui/card";
+import UserAvatar from "@/components/user-avatar";
+import { getAvatarUrl } from "@/lib/avatar";
 import { createClient } from "@/lib/supabase/client";
 import { MapPin } from "lucide-react";
 import UserDetailActivities from "./user-detail-activities";
@@ -42,10 +44,7 @@ export default async function UserDetailPage({ params }: Props) {
   return (
     <div className="flex flex-col items-center p-4 gap-4">
       <div className="flex flex-col items-center">
-        <Avatar className="w-16 h-16">
-          <AvatarImage src="https://github.com/shadcn.png" alt="@user" />
-          <AvatarFallback>アイコン</AvatarFallback>
-        </Avatar>
+        <UserAvatar userProfile={user} size="2xl" />
         <div className="text-xl font-bold mt-2">
           {user.x_username || user.name}
         </div>

--- a/components/user-avatar.tsx
+++ b/components/user-avatar.tsx
@@ -1,6 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { getAvatarUrl } from "@/lib/avatar";
 import { createClient } from "@/lib/supabase/client";
+import clsx from "clsx";
 import type { HTMLProps } from "react";
 
 interface UserProfile {
@@ -10,26 +11,47 @@ interface UserProfile {
 
 interface UserAvatarProps {
   userProfile: UserProfile;
+  size?: "sm" | "md" | "lg" | "xl" | "2xl";
   className?: HTMLProps<HTMLElement>["className"];
 }
 
 export default function UserAvatar({
   className,
   userProfile,
+  size = "md",
 }: UserAvatarProps) {
   const supabase = createClient();
   let avatarUrl = userProfile.avatar_url;
   if (avatarUrl) {
     avatarUrl = getAvatarUrl(supabase, avatarUrl);
   }
+  const sizeClass = {
+    sm: "w-8 h-8",
+    md: "w-10 h-10",
+    lg: "w-16 h-16",
+    xl: "w-24 h-24",
+    "2xl": "w-32 h-32",
+  };
+  const textSizeClass = {
+    sm: "text-base",
+    md: "text-lg",
+    lg: "text-2xl",
+    xl: "text-4xl",
+    "2xl": "text-6xl",
+  };
   return (
-    <Avatar className={className}>
+    <Avatar className={clsx(sizeClass[size], className)}>
       <AvatarImage
         src={avatarUrl || undefined}
         alt="プロフィール画像"
         style={{ objectFit: "cover" }}
       />
-      <AvatarFallback className="bg-emerald-100 text-emerald-700 font-medium">
+      <AvatarFallback
+        className={clsx(
+          "bg-emerald-100 text-emerald-700 font-medium",
+          textSizeClass[size],
+        )}
+      >
         {userProfile.name?.substring(0, 1) ?? "ユ"}
       </AvatarFallback>
     </Avatar>

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -6,6 +6,7 @@ export function getAvatarUrl(
   client: SupabaseClient,
   avatarPath: string,
 ): string {
+  if (!avatarPath) return "";
   const { data } = client.storage.from("avatars").getPublicUrl(avatarPath, {
     transform: {
       width: 240,


### PR DESCRIPTION
# 変更の概要

- アバターアイコン表示の不具合修正

<img width="364" alt="image" src="https://github.com/user-attachments/assets/8b345835-29c7-425e-a9b3-6a69a78581a5" />

# 変更の背景
- アバターアイコンが表示されていなかった
- サイズが小さすぎた

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました