### PR TITLE
feat: 生年月日をselectboxに変更

### DIFF
--- a/app/(protected)/settings/profile/ProfileForm.tsx
+++ b/app/(protected)/settings/profile/ProfileForm.tsx
@@ -14,6 +14,13 @@ import {
 } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { getAvatarUrl } from "@/lib/avatar";
 import { AVATAR_MAX_FILE_SIZE } from "@/lib/avatar";
 import { createClient } from "@/lib/supabase/client";
@@ -64,6 +71,67 @@ export default function ProfileForm({
   const fileInputRef = useRef<HTMLInputElement>(null);
   const router = useRouter();
 
+  // 生年月日関連のステート
+  const initialDate = initialProfile?.date_of_birth
+    ? new Date(initialProfile.date_of_birth)
+    : null;
+  const [selectedYear, setSelectedYear] = useState<number | null>(
+    initialDate ? initialDate.getFullYear() : null,
+  );
+  const [selectedMonth, setSelectedMonth] = useState<number | null>(
+    initialDate ? initialDate.getMonth() + 1 : null,
+  );
+  const [selectedDay, setSelectedDay] = useState<number | null>(
+    initialDate ? initialDate.getDate() : null,
+  );
+
+  // 年の選択肢 (2007年から100年前まで)
+  // なぜ2007年かというと、18歳未満の選挙活動が禁止されており、それを満たす要件は2007年生まれ以前の必要があるため
+  const birthYearThreshold = 2007;
+  const years = Array.from({ length: 100 }, (_, i) => birthYearThreshold - i);
+
+  // 月の選択肢
+  const months = Array.from({ length: 12 }, (_, i) => i + 1);
+
+  // 年月が変更されたら日をリセット
+  // 現在選択されている日がその月の日数を超えている場合は、日をリセットする
+  useEffect(() => {
+    const getDaysInMonth = (year: number, month: number) => {
+      return new Date(year, month, 0).getDate();
+    };
+
+    if (selectedYear && selectedMonth) {
+      const daysInMonth = getDaysInMonth(selectedYear, selectedMonth);
+      if (selectedDay && selectedDay > daysInMonth) {
+        setSelectedDay(null);
+      }
+    } else {
+      setSelectedDay(null);
+    }
+  }, [selectedYear, selectedMonth, selectedDay]);
+
+  // 日の選択肢 (選択された年月に基づいて動的に計算)
+  const days =
+    selectedYear && selectedMonth
+      ? Array.from(
+          { length: new Date(selectedYear, selectedMonth, 0).getDate() },
+          (_, i) => i + 1,
+        )
+      : [];
+
+  // フォーム送信用に日付をフォーマット
+  const formatDate = (
+    year: number | null,
+    month: number | null,
+    day: number | null,
+  ) => {
+    if (!year || !month || !day) return "";
+    // 数値を2桁にフォーマットするヘルパー関数
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    return `${year}-${pad(month)}-${pad(day)}`;
+  };
+
+  const formattedDate = formatDate(selectedYear, selectedMonth, selectedDay);
   useEffect(() => {
     // フォーム送信成功時の処理
     if (state?.success && isNew) {
@@ -185,14 +253,73 @@ export default function ProfileForm({
           </div>
 
           <div className="space-y-2">
-            <Label htmlFor="date_of_birth">生年月日</Label>
-            <Input
-              type="date"
-              name="date_of_birth"
-              required
-              readOnly
-              value={initialProfile?.date_of_birth || ""}
-            />
+            <Label>生年月日</Label>
+            <div className="grid grid-cols-3 gap-2" aria-required="true">
+              <legend className="sr-only">生年月日</legend>
+              <div>
+                <Select
+                  name="year"
+                  value={selectedYear?.toString() || ""}
+                  onValueChange={(value) => setSelectedYear(Number(value))}
+                  required
+                  aria-required="true"
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="年" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {years.map((year) => (
+                      <SelectItem key={year} value={year.toString()}>
+                        {year}年
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Select
+                  name="month"
+                  value={selectedMonth?.toString() || ""}
+                  onValueChange={(value) => setSelectedMonth(Number(value))}
+                  disabled={!selectedYear}
+                  required
+                  aria-required="true"
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="月" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {months.map((month) => (
+                      <SelectItem key={month} value={month.toString()}>
+                        {month}月
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div>
+                <Select
+                  name="day"
+                  value={selectedDay?.toString() || ""}
+                  onValueChange={(value) => setSelectedDay(Number(value))}
+                  disabled={!selectedMonth || !selectedYear}
+                  required
+                  aria-required="true"
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="日" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {days.map((day) => (
+                      <SelectItem key={day} value={day.toString()}>
+                        {day}日
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <input type="hidden" name="date_of_birth" value={formattedDate} />
           </div>
 
           <div className="space-y-2">


### PR DESCRIPTION
# 変更の概要
fix #135 
profileの生年月日をDatePickerからselectbox方式に変更しました

- 「年」の最も若い（つまり最大の）年は2007年としています、これは2025年現在で18歳以上は全て2007年以前の生まれである必要があるからです
- 「年・月」から換算し、日に不正値が入る可能性がある場合は日をリセットする処理を入れています（1月31日を選択→2月を選択した時に2月31日が指定できないようにする処理）

https://github.com/user-attachments/assets/eeeebdb7-e3fb-477d-9ee1-292297c23319

# 変更の背景
- issueにて報告があったため

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました