### PR TITLE
パスワード要件の明示とバリデーション

### DIFF
--- a/app/(auth-pages)/sign-in/SignInForm.tsx
+++ b/app/(auth-pages)/sign-in/SignInForm.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { signInActionWithState } from "@/app/actions";
+import { FormMessage } from "@/components/form-message";
+import { SubmitButton } from "@/components/submit-button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import Link from "next/link";
+import { useActionState } from "react";
+
+export default function SignInForm() {
+  const [state, formAction] = useActionState(signInActionWithState, null);
+
+  return (
+    <form
+      action={formAction}
+      className="flex flex-col gap-2 [&>input]:mb-3 mt-8 min-w-72 max-w-72 mx-auto"
+    >
+      {state?.error && (
+        <FormMessage message={{ error: state.error }} className="mb-4" />
+      )}
+
+      <Label htmlFor="email">メールアドレス</Label>
+      <Input
+        name="email"
+        placeholder="you@example.com"
+        required
+        autoComplete="username"
+        defaultValue={state?.formData?.email || ""}
+      />
+
+      <div className="flex justify-between items-center">
+        <Label htmlFor="password">パスワード</Label>
+        <Link
+          className="text-xs text-foreground underline"
+          href="/forgot-password"
+        >
+          パスワードを忘れた方
+        </Link>
+      </div>
+      <Input
+        type="password"
+        name="password"
+        placeholder="パスワード"
+        required
+        autoComplete="current-password"
+      />
+
+      <SubmitButton pendingText="ログイン中...">ログイン</SubmitButton>
+    </form>
+  );
+}

--- a/app/(auth-pages)/sign-in/page.tsx
+++ b/app/(auth-pages)/sign-in/page.tsx
@@ -1,15 +1,12 @@
-import { signInAction } from "@/app/actions";
 import { FormMessage, type Message } from "@/components/form-message";
-import { SubmitButton } from "@/components/submit-button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import Image from "next/image";
 import Link from "next/link";
+import SignInForm from "./SignInForm";
 
 export default async function Login(props: { searchParams: Promise<Message> }) {
   const searchParams = await props.searchParams;
   return (
-    <form className="flex-1 flex flex-col min-w-72">
+    <div className="flex-1 flex flex-col min-w-72">
       <div className="flex justify-center items-center m-4">
         <Image src="/img/logo.png" alt="logo" width={114} height={96} />
       </div>
@@ -21,34 +18,7 @@ export default async function Login(props: { searchParams: Promise<Message> }) {
         </Link>
       </p>
       <FormMessage className="mt-8" message={searchParams} />
-      <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
-        <Label htmlFor="email">メールアドレス</Label>
-        <Input
-          name="email"
-          placeholder="you@example.com"
-          required
-          autoComplete="username"
-        />
-        <div className="flex justify-between items-center">
-          <Label htmlFor="password">パスワード</Label>
-          <Link
-            className="text-xs text-foreground underline"
-            href="/forgot-password"
-          >
-            パスワードを忘れた方
-          </Link>
-        </div>
-        <Input
-          type="password"
-          name="password"
-          placeholder="パスワード"
-          required
-          autoComplete="current-password"
-        />
-        <SubmitButton pendingText="Signing In..." formAction={signInAction}>
-          ログイン
-        </SubmitButton>
-      </div>
-    </form>
+      <SignInForm />
+    </div>
   );
 }

--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -82,13 +82,16 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
           type="password"
           name="password"
           placeholder="パスワード"
-          minLength={6}
+          minLength={8}
           required
           disabled={isSuccess}
           autoComplete="new-password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
+        <p className="text-sm text-muted-foreground mb-2">
+          ※ 8文字以上32文字以下で英数が含まれること。英数と一部記号が使えます。
+        </p>
 
         <Label htmlFor="date_of_birth">
           生年月日（満18歳以上である必要があります）

--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -62,7 +62,7 @@ function SignUpFormContent({
         />
         <Label htmlFor="password">パスワード</Label>
         <p className="text-xs text-muted-foreground mb-2">
-          ※8文字以上で英数を含めてください。英数と一部記号が使えます。
+          ※8文字以上で半角英数を含めてください。英数と一部記号が使えます。
         </p>
         <Input
           type="password"

--- a/app/(auth-pages)/sign-up/SignUpForm.tsx
+++ b/app/(auth-pages)/sign-up/SignUpForm.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { signUpAction } from "@/app/actions";
+import { signUpActionWithState } from "@/app/actions";
 import { FormMessage, type Message } from "@/components/form-message";
 import { SubmitButton } from "@/components/submit-button";
 import { Checkbox } from "@/components/ui/checkbox";
@@ -8,90 +8,73 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { calculateAge } from "@/lib/utils/utils";
 import Link from "next/link";
-import { useState } from "react";
+import { useActionState, useCallback, useEffect, useState } from "react";
+import { useFormStatus } from "react-dom";
 
 interface SignUpFormProps {
   searchParams: Message;
 }
 
-export default function SignUpForm({ searchParams }: SignUpFormProps) {
-  const [isTermsAgreed, setIsTermsAgreed] = useState(false);
-  const [isPrivacyAgreed, setIsPrivacyAgreed] = useState(false);
-  const [email, setEmail] = useState("");
-  const [password, setPassword] = useState("");
-  const [dateOfBirth, setDateOfBirth] = useState("");
-  const [ageError, setAgeError] = useState<string | null>(null);
-  const [isFormValid, setIsFormValid] = useState(true);
-
-  const isSuccess = "success" in searchParams;
-
-  // 年齢チェック関数
-  const verifyAge = (birthdate: string): boolean => {
-    if (!birthdate) return false;
-
-    const age = calculateAge(birthdate);
-    if (age < 18) {
-      const yearsToWait = 18 - age;
-      const waitText = yearsToWait > 1 ? `あと${yearsToWait}年で` : "もうすぐ";
-      setAgeError(
-        `公職選挙法により18歳以上の方のみ選挙運動に参加できます。${waitText}参画できますので、その日を楽しみにお待ちください！`,
-      );
-      setIsFormValid(false);
-      return false;
-    }
-
-    setAgeError(null);
-    setIsFormValid(true);
-    return true;
-  };
-
-  const handleChangeBirth = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = e.target.value;
-    setDateOfBirth(newValue);
-    // 入力値が変更されたタイミングで年齢検証を実行
-    if (newValue) {
-      verifyAge(newValue);
-    }
-  };
+// フォームコンポーネントを分離してuseFormStatusを使用
+function SignUpFormContent({
+  isTermsAgreed,
+  isPrivacyAgreed,
+  email,
+  password,
+  dateOfBirth,
+  ageError,
+  isFormValid,
+  setIsTermsAgreed,
+  setIsPrivacyAgreed,
+  setEmail,
+  setPassword,
+  setDateOfBirth,
+  handleChangeBirth,
+}: {
+  isTermsAgreed: boolean;
+  isPrivacyAgreed: boolean;
+  email: string;
+  password: string;
+  dateOfBirth: string;
+  ageError: string | null;
+  isFormValid: boolean;
+  setIsTermsAgreed: (value: boolean) => void;
+  setIsPrivacyAgreed: (value: boolean) => void;
+  setEmail: (value: string) => void;
+  setPassword: (value: string) => void;
+  setDateOfBirth: (value: string) => void;
+  handleChangeBirth: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}) {
+  const { pending } = useFormStatus();
 
   return (
-    <form className="flex flex-col min-w-72 max-w-72 mx-auto">
-      <h1 className="text-2xl font-medium text-center mb-2">
-        チームみらいに参画する
-      </h1>
-      <p className="text-sm text-foreground text-center">
-        すでに参画済みの方は{" "}
-        <Link className="text-primary font-medium underline" href="/sign-in">
-          こちら
-        </Link>
-      </p>
-      <FormMessage className="mt-8" message={searchParams} />
+    <>
       <div className="flex flex-col gap-2 [&>input]:mb-3 mt-8">
         <Label htmlFor="email">メールアドレス</Label>
         <Input
           name="email"
           placeholder="you@example.com"
           required
-          disabled={isSuccess}
+          disabled={pending}
           autoComplete="username"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
         />
         <Label htmlFor="password">パスワード</Label>
+        <p className="text-xs text-muted-foreground mb-2">
+          ※8文字以上で英数を含めてください。英数と一部記号が使えます。
+        </p>
         <Input
           type="password"
           name="password"
           placeholder="パスワード"
           minLength={8}
           required
-          disabled={isSuccess}
+          disabled={pending}
           autoComplete="new-password"
           value={password}
           onChange={(e) => setPassword(e.target.value)}
         />
-        <p className="text-sm text-muted-foreground mb-2">
-          ※ 8文字以上32文字以下で英数が含まれること。英数と一部記号が使えます。
-        </p>
 
         <Label htmlFor="date_of_birth">
           生年月日（満18歳以上である必要があります）
@@ -100,7 +83,7 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
           type="date"
           name="date_of_birth"
           required
-          disabled={isSuccess}
+          disabled={pending}
           autoComplete="bday"
           value={dateOfBirth}
           onChange={handleChangeBirth}
@@ -115,6 +98,12 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
               id="terms"
               checked={isTermsAgreed}
               onCheckedChange={(checked) => setIsTermsAgreed(checked === true)}
+              disabled={pending}
+            />
+            <input
+              type="hidden"
+              name="terms_agreed"
+              value={isTermsAgreed ? "true" : "false"}
             />
             <Label
               htmlFor="terms"
@@ -138,6 +127,12 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
               onCheckedChange={(checked) =>
                 setIsPrivacyAgreed(checked === true)
               }
+              disabled={pending}
+            />
+            <input
+              type="hidden"
+              name="privacy_agreed"
+              value={isPrivacyAgreed ? "true" : "false"}
             />
             <Label
               htmlFor="privacy"
@@ -156,8 +151,7 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
         </div>
 
         <SubmitButton
-          formAction={signUpAction}
-          pendingText="Signing up..."
+          pendingText="サインアップ中..."
           disabled={
             !isTermsAgreed ||
             !isPrivacyAgreed ||
@@ -165,12 +159,110 @@ export default function SignUpForm({ searchParams }: SignUpFormProps) {
             !password ||
             !dateOfBirth ||
             !isFormValid ||
-            isSuccess
+            pending
           }
         >
           サインアップ
         </SubmitButton>
       </div>
+    </>
+  );
+}
+
+export default function SignUpForm({ searchParams }: SignUpFormProps) {
+  // useActionStateを使用してフォームの状態とメッセージを管理
+  const [state, formAction] = useActionState(signUpActionWithState, null);
+
+  // フォームの状態管理
+  const [isTermsAgreed, setIsTermsAgreed] = useState(false);
+  const [isPrivacyAgreed, setIsPrivacyAgreed] = useState(false);
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [dateOfBirth, setDateOfBirth] = useState("");
+  const [ageError, setAgeError] = useState<string | null>(null);
+  const [isFormValid, setIsFormValid] = useState(true);
+
+  // 年齢チェック関数
+  const verifyAge = useCallback((birthdate: string): boolean => {
+    if (!birthdate) return false;
+
+    const age = calculateAge(birthdate);
+    if (age < 18) {
+      const yearsToWait = 18 - age;
+      const waitText = yearsToWait > 1 ? `あと${yearsToWait}年で` : "もうすぐ";
+      setAgeError(
+        `公職選挙法により18歳以上の方のみ選挙運動に参加できます。${waitText}参画できますので、その日を楽しみにお待ちください！`,
+      );
+      setIsFormValid(false);
+      return false;
+    }
+
+    setAgeError(null);
+    setIsFormValid(true);
+    return true;
+  }, []);
+
+  // サーバーから返されたフォームデータで状態を復元
+  useEffect(() => {
+    if (state?.formData) {
+      setIsTermsAgreed(state.formData.terms_agreed);
+      setIsPrivacyAgreed(state.formData.privacy_agreed);
+      setEmail(state.formData.email);
+      setPassword(state.formData.password);
+      setDateOfBirth(state.formData.date_of_birth);
+
+      // 生年月日が設定されている場合は年齢チェックを実行
+      if (state.formData.date_of_birth) {
+        verifyAge(state.formData.date_of_birth);
+      }
+    }
+  }, [state, verifyAge]);
+
+  const handleChangeBirth = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setDateOfBirth(newValue);
+    // 入力値が変更されたタイミングで年齢検証を実行
+    if (newValue) {
+      verifyAge(newValue);
+    }
+  };
+
+  return (
+    <form
+      action={formAction}
+      className="flex flex-col min-w-72 max-w-72 mx-auto"
+    >
+      <h1 className="text-2xl font-medium text-center mb-2">
+        チームみらいに参画する
+      </h1>
+      <p className="text-sm text-foreground text-center">
+        すでに参画済みの方は{" "}
+        <Link className="text-primary font-medium underline" href="/sign-in">
+          こちら
+        </Link>
+      </p>
+
+      {/* サーバーアクションからのメッセージを表示 */}
+      {state && <FormMessage className="mt-8" message={state} />}
+
+      {/* 元のsearchParamsからのメッセージも表示（後方互換性のため） */}
+      <FormMessage className="mt-8" message={searchParams} />
+
+      <SignUpFormContent
+        isTermsAgreed={isTermsAgreed}
+        isPrivacyAgreed={isPrivacyAgreed}
+        email={email}
+        password={password}
+        dateOfBirth={dateOfBirth}
+        ageError={ageError}
+        isFormValid={isFormValid}
+        setIsTermsAgreed={setIsTermsAgreed}
+        setIsPrivacyAgreed={setIsPrivacyAgreed}
+        setEmail={setEmail}
+        setPassword={setPassword}
+        setDateOfBirth={setDateOfBirth}
+        handleChangeBirth={handleChangeBirth}
+      />
     </form>
   );
 }

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -98,6 +98,61 @@ export const signUpActionWithState = async (
   );
 };
 
+// useActionState用のサインインアクション
+export const signInActionWithState = async (
+  prevState: {
+    error?: string;
+    success?: string;
+    message?: string;
+    formData?: {
+      email: string;
+    };
+  } | null,
+  formData: FormData,
+) => {
+  const email = formData.get("email")?.toString();
+  const password = formData.get("password")?.toString();
+
+  // フォームデータを保存（エラー時の状態復元用、メールアドレスのみ）
+  const currentFormData = {
+    email: email || "",
+  };
+
+  const validatedFields = signInAndLoginFormSchema.safeParse({
+    email,
+    password,
+  });
+  if (!validatedFields.success) {
+    return {
+      error: "メールアドレスまたはパスワードが間違っています",
+      formData: currentFormData,
+    };
+  }
+
+  if (!email || !password) {
+    return {
+      error: "メールアドレスまたはパスワードが間違っています",
+      formData: currentFormData,
+    };
+  }
+
+  const supabase = await createClient();
+
+  const { error } = await supabase.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error) {
+    return {
+      error: "メールアドレスまたはパスワードが間違っています",
+      formData: currentFormData,
+    };
+  }
+
+  return redirect("/");
+};
+
 export const signInAction = async (formData: FormData) => {
   const email = formData.get("email") as string;
   const password = formData.get("password") as string;
@@ -110,7 +165,7 @@ export const signInAction = async (formData: FormData) => {
     return encodedRedirect(
       "error",
       "/sign-in",
-      validatedFields.error.errors.map((error) => error.message).join("\n"),
+      "メールアドレスまたはパスワードが間違っています",
     );
   }
 

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -5,42 +5,11 @@ import { calculateAge, encodedRedirect } from "@/lib/utils/utils";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-import { z } from "zod";
-
-const signUpAndLoginFormSchema = z.object({
-  email: z
-    .string()
-    .nonempty({ message: "メールアドレスを入力してください" })
-    .email({ message: "有効なメールアドレスを入力してください" }),
-  password: z
-    .string()
-    .nonempty({ message: "パスワードを入力してください" })
-    .min(6, { message: "パスワードは8文字以上で入力してください" }),
-  date_of_birth: z
-    .string()
-    .nonempty({ message: "生年月日を入力してください" })
-    .refine(
-      (value) => {
-        const age = calculateAge(value);
-        return age >= 18;
-      },
-      {
-        message: "18歳未満の方は登録できません",
-      },
-    )
-    .transform((value) => new Date(value).toISOString()), // ISO形式に変換
-});
-
-const signInAndLoginFormSchema = z.object({
-  email: z
-    .string()
-    .nonempty({ message: "メールアドレスを入力してください" })
-    .email({ message: "有効なメールアドレスを入力してください" }),
-  password: z
-    .string()
-    .nonempty({ message: "パスワードを入力してください" })
-    .min(8, { message: "パスワードは8文字以上で入力してください" }),
-});
+import {
+  forgotPasswordFormSchema,
+  signInAndLoginFormSchema,
+  signUpAndLoginFormSchema,
+} from "@/lib/validation/auth";
 
 export const signUpAction = async (formData: FormData) => {
   const email = formData.get("email")?.toString();
@@ -129,13 +98,6 @@ export const signInAction = async (formData: FormData) => {
 
   return redirect("/");
 };
-
-const forgotPasswordFormSchema = z.object({
-  email: z
-    .string()
-    .nonempty({ message: "メールアドレスを入力してください" })
-    .email({ message: "有効なメールアドレスを入力してください" }),
-});
 
 export const forgotPasswordAction = async (formData: FormData) => {
   const email = formData.get("email")?.toString();

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,10 @@ require("dotenv").config({ path: ".env" });
 module.exports = {
   preset: "ts-jest",
   testEnvironment: "node",
-  testMatch: ["**/tests/rls/**/*.test.ts"],
+  testMatch: ["**/tests/**/*.test.ts"],
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/$1",
+  },
   transform: {
     "^.+\\.tsx?$": [
       "ts-jest",

--- a/lib/validation/auth.ts
+++ b/lib/validation/auth.ts
@@ -1,0 +1,53 @@
+import { calculateAge } from "@/lib/utils/utils";
+import { z } from "zod";
+
+// パスワードの許可文字の正規表現
+const ALLOWED_PASSWORD_CHARS_REGEX = /^[a-zA-Z0-9@+*/#$%&!\-]*$/;
+// パスワードが英字と数字の両方を含むかチェックする正規表現
+const ALPHANUMERIC_REQUIRED_REGEX = /(?=.*[a-zA-Z])(?=.*[0-9])/;
+
+// メールアドレスのバリデーションスキーマ（再利用可能）
+const emailSchema = z
+  .string()
+  .nonempty({ message: "メールアドレスを入力してください" })
+  .email({ message: "有効なメールアドレスを入力してください" });
+
+// パスワードのバリデーションスキーマ（再利用可能）
+export const passwordSchema = z
+  .string()
+  .nonempty({ message: "パスワードを入力してください" })
+  .min(8, { message: "パスワードは8文字以上で入力してください" })
+  .max(32, { message: "パスワードは32文字以下で入力してください" })
+  .regex(ALLOWED_PASSWORD_CHARS_REGEX, {
+    message: "パスワードに無効な文字が含まれています",
+  })
+  .regex(ALPHANUMERIC_REQUIRED_REGEX, {
+    message: "パスワードには英字と数字の両方を含めてください",
+  });
+
+export const signUpAndLoginFormSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+  date_of_birth: z
+    .string()
+    .nonempty({ message: "生年月日を入力してください" })
+    .refine(
+      (value) => {
+        const age = calculateAge(value);
+        return age >= 18;
+      },
+      {
+        message: "18歳未満の方は登録できません",
+      },
+    )
+    .transform((value) => new Date(value).toISOString()), // ISO形式に変換
+});
+
+export const signInAndLoginFormSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+export const forgotPasswordFormSchema = z.object({
+  email: emailSchema,
+});

--- a/tests/validation/auth.test.ts
+++ b/tests/validation/auth.test.ts
@@ -1,0 +1,254 @@
+import {
+  passwordSchema,
+  signInAndLoginFormSchema,
+  signUpAndLoginFormSchema,
+} from "@/lib/validation/auth";
+
+describe("パスワードバリデーション", () => {
+  describe("passwordSchema", () => {
+    describe("正常なパスワード", () => {
+      test("8文字の英数字組み合わせ", () => {
+        const result = passwordSchema.safeParse("abc123de");
+        expect(result.success).toBe(true);
+      });
+
+      test("許可された記号を含む", () => {
+        const validPasswords = [
+          "pass123@",
+          "test123+",
+          "user123-",
+          "data123*",
+          "code123/",
+          "app1234#",
+          "web1234$",
+          "api1234%",
+          "dev1234&",
+          "pwd1234!",
+        ];
+
+        for (const password of validPasswords) {
+          const result = passwordSchema.safeParse(password);
+          if (!result.success) {
+            console.log(
+              `Failed password: "${password}", errors:`,
+              result.error?.issues,
+            );
+          }
+          expect(result.success).toBe(true);
+        }
+      });
+
+      test("32文字ちょうどのパスワード", () => {
+        const result = passwordSchema.safeParse(
+          "abcdefghijklmnopqrstuvwxyz123456",
+        ); // 32文字
+        expect(result.success).toBe(true);
+      });
+
+      test("大文字小文字数字の組み合わせ", () => {
+        const result = passwordSchema.safeParse("AbC123dE");
+        expect(result.success).toBe(true);
+      });
+    });
+
+    describe("無効なパスワード", () => {
+      test("空文字", () => {
+        const result = passwordSchema.safeParse("");
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードを入力してください",
+        );
+      });
+
+      test("7文字以下", () => {
+        const result = passwordSchema.safeParse("abc123");
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードは8文字以上で入力してください",
+        );
+      });
+
+      test("33文字以上", () => {
+        const result = passwordSchema.safeParse(
+          "abcdefghijklmnopqrstuvwxyz1234567",
+        ); // 33文字
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードは32文字以下で入力してください",
+        );
+      });
+
+      test("英字のみ", () => {
+        const result = passwordSchema.safeParse("abcdefgh");
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードには英字と数字の両方を含めてください",
+        );
+      });
+
+      test("数字のみ", () => {
+        const result = passwordSchema.safeParse("12345678");
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードには英字と数字の両方を含めてください",
+        );
+      });
+
+      test("許可されていない記号を含む", () => {
+        const invalidPasswords = [
+          "pass123.",
+          "test123,",
+          "user123;",
+          "data123:",
+          "code123?",
+          "app1234<",
+          "web1234>",
+          "api1234=",
+          "dev1234[",
+          "pwd1234]",
+          "abc1234{",
+          "def1234}",
+          "ghi1234|",
+          "jkl1234\\",
+          "mno1234'",
+          'pqr1234"',
+          "stu1234~",
+          "vwx1234`",
+        ];
+
+        for (const password of invalidPasswords) {
+          const result = passwordSchema.safeParse(password);
+          expect(result.success).toBe(false);
+          expect(result.error?.issues[0].message).toBe(
+            "パスワードに無効な文字が含まれています",
+          );
+        }
+      });
+
+      test("日本語を含む", () => {
+        const result = passwordSchema.safeParse("パスワード123");
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードに無効な文字が含まれています",
+        );
+      });
+
+      test("スペースを含む", () => {
+        const result = passwordSchema.safeParse("pass 123");
+        expect(result.success).toBe(false);
+        expect(result.error?.issues[0].message).toBe(
+          "パスワードに無効な文字が含まれています",
+        );
+      });
+    });
+  });
+
+  describe("signUpAndLoginFormSchema", () => {
+    const validBaseData = {
+      email: "test@example.com",
+      password: "password123",
+      date_of_birth: "1990-01-01",
+    };
+
+    test("正常なデータでサインアップ成功", () => {
+      const result = signUpAndLoginFormSchema.safeParse(validBaseData);
+      expect(result.success).toBe(true);
+    });
+
+    test("無効なパスワードでサインアップ失敗", () => {
+      const invalidData = {
+        ...validBaseData,
+        password: "short",
+      };
+      const result = signUpAndLoginFormSchema.safeParse(invalidData);
+      expect(result.success).toBe(false);
+    });
+
+    test("無効なメールアドレスでサインアップ失敗", () => {
+      const invalidData = {
+        ...validBaseData,
+        email: "invalid-email",
+      };
+      const result = signUpAndLoginFormSchema.safeParse(invalidData);
+      expect(result.success).toBe(false);
+    });
+
+    test("18歳未満でサインアップ失敗", () => {
+      const currentYear = new Date().getFullYear();
+      const invalidData = {
+        ...validBaseData,
+        date_of_birth: `${currentYear - 17}-01-01`,
+      };
+      const result = signUpAndLoginFormSchema.safeParse(invalidData);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("signInAndLoginFormSchema", () => {
+    const validBaseData = {
+      email: "test@example.com",
+      password: "password123",
+    };
+
+    test("正常なデータでサインイン成功", () => {
+      const result = signInAndLoginFormSchema.safeParse(validBaseData);
+      expect(result.success).toBe(true);
+    });
+
+    test("無効なパスワードでサインイン失敗", () => {
+      const invalidData = {
+        ...validBaseData,
+        password: "123",
+      };
+      const result = signInAndLoginFormSchema.safeParse(invalidData);
+      expect(result.success).toBe(false);
+    });
+
+    test("無効なメールアドレスでサインイン失敗", () => {
+      const invalidData = {
+        ...validBaseData,
+        email: "not-an-email",
+      };
+      const result = signInAndLoginFormSchema.safeParse(invalidData);
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe("パスワード要件の詳細テスト", () => {
+    test("許可される文字セットの境界値テスト", () => {
+      // 英小文字の境界
+      expect(passwordSchema.safeParse("abcdefg1").success).toBe(true);
+      expect(passwordSchema.safeParse("zzzzzzz1").success).toBe(true);
+
+      // 英大文字の境界
+      expect(passwordSchema.safeParse("ABCDEFG1").success).toBe(true);
+      expect(passwordSchema.safeParse("ZZZZZZZ1").success).toBe(true);
+
+      // 数字の境界
+      expect(passwordSchema.safeParse("abcdefg0").success).toBe(true);
+      expect(passwordSchema.safeParse("abcdefg9").success).toBe(true);
+
+      // 許可される記号の全種類
+      const allowedSymbols = "@+-*/#$%&!";
+      for (const symbol of allowedSymbols) {
+        expect(passwordSchema.safeParse(`abc123${symbol}d`).success).toBe(true);
+      }
+    });
+
+    test("最小長ちょうどのパスワード", () => {
+      expect(passwordSchema.safeParse("abcd1234").success).toBe(true); // 8文字ちょうど
+      expect(passwordSchema.safeParse("abcd123").success).toBe(false); // 7文字
+    });
+
+    test("英数字の組み合わせパターン", () => {
+      // 英字1文字 + 数字7文字
+      expect(passwordSchema.safeParse("a1234567").success).toBe(true);
+
+      // 英字7文字 + 数字1文字
+      expect(passwordSchema.safeParse("abcdefg1").success).toBe(true);
+
+      // 交互パターン
+      expect(passwordSchema.safeParse("a1b2c3d4").success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
# 変更の概要

- サインアップ時にパスワード要件の明示 (8桁以上 英数を含む 一部記号が使える)
- パスワード要件のバリデーション実装
- エラーでサインアップフォームの内容が消える不具合の修正

fix #161 

# 変更の背景

- パスワードの要件が不明だった

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](../CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました