### PR TITLE
fix secrets naming in cloudbuild.yaml and terraform files

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -77,7 +77,7 @@ images:
 
 availableSecrets:
   secretManager:
-    - versionName: 'projects/${PROJECT_ID}/secrets/SUPABASE_ACCESS_TOKEN/versions/latest'
+    - versionName: 'projects/${PROJECT_ID}/secrets/${_SERVICE_NAME}-supabase-access-token/versions/latest'
       env: SUPABASE_ACCESS_TOKEN
-    - versionName: 'projects/${PROJECT_ID}/secrets/SUPABASE_DB_PASSWORD/versions/latest'
+    - versionName: 'projects/${PROJECT_ID}/secrets/${_SERVICE_NAME}-supabase-db-password/versions/latest'
       env: SUPABASE_DB_PASSWORD

--- a/terraform/nextjs-app/secrets.tf
+++ b/terraform/nextjs-app/secrets.tf
@@ -24,7 +24,7 @@ resource "google_secret_manager_secret_version" "supabase_access_token" {
 }
 
 resource "google_secret_manager_secret" "supabase_db_password" {
-  secret_id = "${var.app_name}-${var.environment}-SUPABASE_DB_PASSWORD"
+  secret_id = "${var.app_name}-${var.environment}-supabase-db-password"
 
   replication {
     auto {}


### PR DESCRIPTION
# 変更の概要
- terraform の secrets と cloudbuild.yaml の参照を合わせる

# 変更の背景
- 環境変数のリファクタを行ったときに変更し忘れている。(build に失敗している)

# CLAへの同意
- 本リポジトリへのコントリビュートには、[コントリビューターライセンス契約（CLA）](https://github.com/team-mirai/action-board/blob/develop/CLA.md)に同意することが必須です。
内容をお読みいただき、下記のチェックボックスにチェックをつける（"- [ ]" を "- [x]" に書き換える）ことで同意したものとみなします。

- [x] CLAの内容を読み、同意しました